### PR TITLE
Move city from Company to Job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /log/*
 !/log/.keep
 /tmp
+.byebug_history

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 You will be working with the existing code in this repository to modify a personal job tracking app. Imagine that your close friend has learned just enough rails to be dangerous, and has started to create an app to track job opportunities they find interesting. They are planning to maintain this site themselves (i.e. they will be adding all companies and jobs, and don’t anticipate companies or other users posting/reviewing jobs). The application currently has the following functionality:
 
 * Jobs can be created and read.
-* Jobs have a title, description, and level_of_interest.
+* Jobs have a title, description, a city, and level_of_interest.
 * Companies can be created, read, updated, and deleted.
-* Companies have a name and location.
+* Companies have a name.
 * A Job `belongs_to` a Company, and a Company `has_many` jobs.
 
 You will be to add the following functionality to this application.
@@ -36,7 +36,7 @@ You will be to add the following functionality to this application.
 
 ### Comments
 
-* When the user visits the page for a specific Job, in addition to information about the job there is a form that allows them to enter a Comment for that Job (e.g. “Spoke to hiring manager, Jacob. Plan to follow up Monday.”). 
+* When the user visits the page for a specific Job, in addition to information about the job there is a form that allows them to enter a Comment for that Job (e.g. “Spoke to hiring manager, Jacob. Plan to follow up Monday.”).
 * Each comment has content (also created_at and updated_at).
 * When the user submits a new comment, they are redirected back to the page for that specific job and the comment appears on the page.
 * The user can leave multiple comments on a job and the most recent comments are shown above older comments (in reverse of the order in which they were created).
@@ -49,11 +49,11 @@ You will be to add the following functionality to this application.
 
 ### Analysis
 
-* The user can visit `/companies?sort=location` to view a list of the companies with their respective jobs sorted by `city`.
+* The user can visit `/jobs?sort=location` to view a list of the jobs sorted by `city`.
 * The user can visit `/dashboard` to see
 * A count of jobs by `level_of_interest`
 * The top three companies ranked by average level of interest along with their respective average level of interest.
-* A count of jobs by `location` with a link to visit a page with companies only in that location. The url should be `/companies?location=Denver`.
+* A count of jobs by `location` with a link to visit a page with jobs only in that location. The url should be `/jobs?location=Denver`.
 * The user can visit `/jobs?sort=interest` to view a list of the jobs sorted by `level_of_interest`.
 
 ## Extensions:
@@ -86,7 +86,7 @@ You will be to add the following functionality to this application.
 ### 3) Controllers
 
 * 4: The developer has moved logic out of the controllers and into the models/POROs where appropriate. The developer uses strong params in a private method. Instance variables being passed to views are appropriately named and limited in number. The developer can speak to each choice made when questioned.
-* 3: Some logic may leak into the controllers that would more appropriately exist in a model/PORO. The developer may pass more instance variables than necessary to the view. 
+* 3: Some logic may leak into the controllers that would more appropriately exist in a model/PORO. The developer may pass more instance variables than necessary to the view.
 * 2: Significant logic exists in the controllers. Methods may be more complicated than necessary. Most functionality is still supported.
 * 1: Significant functionality may be missing. Significant logic may be present, and it is difficult to understand at a glance the purpose of each method.
 

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -39,6 +39,6 @@ class JobsController < ApplicationController
   private
 
   def job_params
-    params.require(:job).permit(:title, :description, :level_of_interest)
+    params.require(:job).permit(:title, :description, :level_of_interest, :city)
   end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,5 +1,5 @@
 class Company < ActiveRecord::Base
-  validates :name, :city, presence: true
+  validates :name, presence: true
   validates :name, uniqueness: true
   has_many :jobs
 end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -1,4 +1,4 @@
 class Job < ActiveRecord::Base
-  validates :title, :level_of_interest, presence: true
+  validates :title, :level_of_interest, :city, presence: true
   belongs_to :company
 end

--- a/app/views/companies/_form.html.erb
+++ b/app/views/companies/_form.html.erb
@@ -2,8 +2,5 @@
   <%= f.label :name %>
   <%= f.text_field :name %>
 
-  <%= f.label :city %>
-  <%= f.text_field :city %>
-
   <%= f.submit %>
 <% end %>

--- a/app/views/companies/index.html.erb
+++ b/app/views/companies/index.html.erb
@@ -2,7 +2,7 @@
 
 <% @companies.each do |company| %>
   <ul class=company_<%= company.id %>>
-    <%= link_to company.name, company_path(company) %> - <%= company.city %><br>
+    <%= link_to company.name, company_path(company) %><br>
     <%= link_to "Edit", edit_company_path(company) %>
     <%= link_to "Delete", company_path(company), method: "delete" %>
   </ul>

--- a/app/views/jobs/_form.html.erb
+++ b/app/views/jobs/_form.html.erb
@@ -8,5 +8,8 @@
   <%= f.label :level_of_interest %>
   <%= f.number_field :level_of_interest %>
 
+  <%= f.label :city %>
+  <%= f.text_field :city %>
+
   <%= f.submit %>
 <% end %>

--- a/app/views/jobs/show.html.erb
+++ b/app/views/jobs/show.html.erb
@@ -7,4 +7,7 @@ Description: <%= @job.description %>
 Level of Interest: <%= @job.level_of_interest %>
 <br>
 
+City: <%= @job.city %>
+<br>
+
 Company: <%= link_to @job.company.name, company_path(@job.company) %>

--- a/db/migrate/20161214181448_remove_city_from_companies.rb
+++ b/db/migrate/20161214181448_remove_city_from_companies.rb
@@ -1,0 +1,5 @@
+class RemoveCityFromCompanies < ActiveRecord::Migration
+  def change
+    remove_column :companies, :city
+  end
+end

--- a/db/migrate/20161214181533_add_city_to_jobs.rb
+++ b/db/migrate/20161214181533_add_city_to_jobs.rb
@@ -1,0 +1,5 @@
+class AddCityToJobs < ActiveRecord::Migration
+  def change
+    add_column :jobs, :city, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,14 +11,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161017195715) do
+ActiveRecord::Schema.define(version: 20161214181533) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "companies", force: :cascade do |t|
     t.string   "name"
-    t.string   "city"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -30,6 +29,7 @@ ActiveRecord::Schema.define(version: 20161017195715) do
     t.datetime "created_at",        null: false
     t.datetime "updated_at",        null: false
     t.integer  "company_id"
+    t.string   "city"
   end
 
   add_index "jobs", ["company_id"], name: "index_jobs_on_company_id", using: :btree

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,8 +6,10 @@ JOBS = ["Engineering", "Development", "Dev Ops", "Quality Assurance", "Teacher",
 CITIES = ["Seattle", "Denver", "Portland", "Indianapolis", "Madison", "Orlando", "San Diego", "Austin", "Las Vegas", "Little Rock", "Boise", "Eugene", "Oakland"]
 
 COMPANIES.each do |name|
-  company = Company.create!(name: name, city: CITIES.sample)
+  company = Company.create!(name: name)
+  puts "Created #{company.name}"
   10.times do |num|
-    company.jobs.create!(title: JOBS.sample, description: "What a great position!", level_of_interest: num + rand(100))
+    company.jobs.create!(title: JOBS.sample, description: "What a great position!", level_of_interest: num + rand(100), city: CITIES.sample)
+    puts "  Created #{company.jobs[num].title}"
   end
 end

--- a/spec/features/companies/user_creates_new_company_spec.rb
+++ b/spec/features/companies/user_creates_new_company_spec.rb
@@ -5,7 +5,6 @@ describe "User creates a new company" do
     visit new_company_path
 
     fill_in "company[name]", with: "ESPN"
-    fill_in "company[city]", with: "LA"
     click_button "Create"
 
     expect(current_path).to eq("/companies/#{Company.last.id}/jobs")

--- a/spec/features/companies/user_deletes_a_company_spec.rb
+++ b/spec/features/companies/user_deletes_a_company_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe "User deletes existing company" do
   scenario "a user can delete a company" do
-    company = Company.create(name: "ESPN", city: "LA")
+    company = Company.create(name: "ESPN")
     visit companies_path
 
     within(".company_#{company.id}") do

--- a/spec/features/companies/user_edits_existing_company_spec.rb
+++ b/spec/features/companies/user_edits_existing_company_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe "User edits an existing company" do
   scenario "a user can edit a company" do
-    company = Company.create(name: "ESPN", city: "LA")
+    company = Company.create(name: "ESPN")
     visit edit_company_path(company)
 
     fill_in "company[name]", with: "EA Sports"

--- a/spec/features/companies/user_sees_all_companies_spec.rb
+++ b/spec/features/companies/user_sees_all_companies_spec.rb
@@ -2,13 +2,12 @@ require 'rails_helper'
 
 describe "User sees all companies" do
   scenario "a user sees all the companies" do
-    company = Company.create(name: "ESPN", city: "LA")
-    company_two = Company.create(name: "Disney", city: "LA")
+    company = Company.create(name: "ESPN")
+    company_two = Company.create(name: "Disney")
 
     visit companies_path
 
     expect(page).to have_content("ESPN")
-    expect(page).to have_content("LA")
   end
 
 end

--- a/spec/features/companies/user_sees_one_company_spec.rb
+++ b/spec/features/companies/user_sees_one_company_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 describe "User sees one company" do
   scenario "a user sees a company" do
-    company = Company.create(name: "ESPN", city: "LA")
-    company.jobs.create(title: "Developer", level_of_interest: 90)
+    company = Company.create(name: "ESPN")
+    company.jobs.create(title: "Developer", level_of_interest: 90, city: "Denver")
 
     visit company_path(company)
 

--- a/spec/features/jobs/user_creates_new_job_spec.rb
+++ b/spec/features/jobs/user_creates_new_job_spec.rb
@@ -2,12 +2,13 @@ require 'rails_helper'
 
 describe "User creates a new job" do
   scenario "a user can create a new job" do
-    company = Company.create(name: "ESPN", city: "NYC")
+    company = Company.create(name: "ESPN")
     visit new_company_job_path(company)
 
     fill_in "job[title]", with: "Developer"
     fill_in "job[description]", with: "So fun!"
     fill_in "job[level_of_interest]", with: 80
+    fill_in "job[city]", with: "Denver"
 
     click_button "Create"
 
@@ -15,5 +16,6 @@ describe "User creates a new job" do
     expect(page).to have_content("ESPN")
     expect(page).to have_content("Developer")
     expect(page).to have_content("80")
+    expect(page).to have_content("Denver")
   end
 end

--- a/spec/features/jobs/user_sees_a_job_spec.rb
+++ b/spec/features/jobs/user_sees_a_job_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 describe "User sees a specific job" do
   scenario "a user sees a job for a specific company" do
-    company = Company.create(name: "ESPN", city: "LA")
-    job = company.jobs.create(title: "Developer", level_of_interest: 70)
+    company = Company.create(name: "ESPN")
+    job = company.jobs.create(title: "Developer", level_of_interest: 70, city: "Denver")
 
     visit company_job_path(company, job)
 

--- a/spec/features/jobs/user_sees_all_jobs_spec.rb
+++ b/spec/features/jobs/user_sees_all_jobs_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 describe "User sees all jobs" do
   scenario "a user sees all the jobs for a specific company" do
-    company = Company.create(name: "ESPN", city: "LA")
-    company.jobs.create(title: "Developer", level_of_interest: 70)
-    company.jobs.create(title: "QA Analyst", level_of_interest: 70)
+    company = Company.create(name: "ESPN")
+    company.jobs.create(title: "Developer", level_of_interest: 70, city: "Denver")
+    company.jobs.create(title: "QA Analyst", level_of_interest: 70, city: "New York City")
 
     visit company_path(company)
 

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -4,25 +4,20 @@ describe Company do
   describe "validations" do
     context "invalid attributes" do
       it "is invalid without a name" do
-        company = Company.new(city: "Denver")
-        expect(company).to be_invalid
-      end
-
-      it "is invalid without a city" do
-        company = Company.new(name: "Ericsson")
+        company = Company.new()
         expect(company).to be_invalid
       end
 
       it "has a unique name" do
-        Company.create(name: "Dropbox", city: "Denver")
+        Company.create(name: "Dropbox")
         company = Company.new(name: "Dropbox")
         expect(company).to be_invalid
       end
     end
 
     context "valid attributes" do
-      it "is valid with a name and city" do
-        company = Company.new(name: "Dropbox", city: "Denver")
+      it "is valid with a name" do
+        company = Company.new(name: "Dropbox")
         expect(company).to be_valid
       end
     end
@@ -30,7 +25,7 @@ describe Company do
 
   describe "relationships" do
     it "has many jobs" do
-      company = Company.new(name: "Dropbox", city: "Denver")
+      company = Company.new(name: "Dropbox")
       expect(company).to respond_to(:jobs)
     end
   end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -4,19 +4,24 @@ describe Job do
   describe "validations" do
     context "invalid attributes" do
       it "is invalid without a title" do
-        job = Job.new(level_of_interest: 80, description: "Wahoo")
+        job = Job.new(level_of_interest: 80, description: "Wahoo", city: "Denver")
         expect(job).to be_invalid
       end
 
       it "is invalid without a level of interest" do
-        job = Job.new(title: "Developer", description: "Wahoo")
+        job = Job.new(title: "Developer", description: "Wahoo", city: "Denver")
+        expect(job).to be_invalid
+      end
+
+      it "is invalid without a city" do
+        job = Job.new(title: "Developer", description: "Wahoo", level_of_interest: 80)
         expect(job).to be_invalid
       end
     end
 
     context "valid attributes" do
       it "is valid with a title and level of interest" do
-        job = Job.new(title: "Developer", level_of_interest: 40)
+        job = Job.new(title: "Developer", level_of_interest: 40, city: "Denver")
         expect(job).to be_valid
       end
     end


### PR DESCRIPTION
@case-eee Think this is ready.

* Updates the readme to reflect the fact that city is now on Job instead of Company
* Creates two new migrations to remove city from Company and add it to Job
* Moves validation for city from Company to Job
* Moves city in forms from Company to Job
* Moves city from Company index to Job show
* Updates seed file to reflect new schema
* Updates specs to match new schema

Also:

* Removes some trailing whitespace in the readme
* Adds `.byebug_history` to the `.gitignore`